### PR TITLE
Avoid string concatenation for name generation

### DIFF
--- a/src/abt/examples/LambdaCalc.scala
+++ b/src/abt/examples/LambdaCalc.scala
@@ -43,6 +43,8 @@ object LambdaCalc {
   //Needed reexports
   type Term = lambdaAbt.Term
   val Var = lambdaAbt.Var
+  type Name = ABTs.Name
+  val Name = ABTs.Name
   implicit val TermOps = lambdaAbt.TermOps _
 
   //

--- a/test-src/abt/examples/BidirTests.scala
+++ b/test-src/abt/examples/BidirTests.scala
@@ -10,7 +10,7 @@ import org.scalatest.FunSuite
  */
 class BidirTests extends FunSuite {
   test("Simple tests for bidirectional type checking") ({
-    check(Map("x" -> Base), Var("x"), Base)
+    check(Map(Name("x") -> Base), Var("x"), Base)
     val tId = Arrow(Base, Base)
     check(Map.empty, Lam("x", Var("x")), tId)
     check(Map.empty, Lam("x", Var("x")), Arrow(tId, tId))


### PR DESCRIPTION
String concatenation can be expensive — I needed this change in
LinqOnSteroids years ago to remove a hotspot.

This _might_ be overkill, but I like it better _and_ I don't want diverging branches in this small project, so merging.
